### PR TITLE
Added ability to load language files from registered namespaces

### DIFF
--- a/src/Waavi/Translation/Loaders/Loader.php
+++ b/src/Waavi/Translation/Loaders/Loader.php
@@ -200,4 +200,15 @@ class Loader implements LoaderInterface {
 			$this->laravelFileLoader->addNamespace($namespace, $hint);
 		}
 	}
+
+	/**
+	 * Return all registered namespaces
+	 * 
+	 * @return array
+	 */
+	public function getHints() 
+	{
+		return $this->hints;
+	}
+
 }

--- a/src/Waavi/Translation/TranslationServiceProvider.php
+++ b/src/Waavi/Translation/TranslationServiceProvider.php
@@ -69,6 +69,10 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider {
 			$languageProvider 	= new LanguageProvider($app['config']['waavi/translation::language.model']);
 			$langEntryProvider 	= new LanguageEntryProvider($app['config']['waavi/translation::language_entry.model']);
 
+			if($app->runningInConsole()){
+				return new FileLoader($languageProvider, $langEntryProvider, $app);
+			}
+
 			$mode = $app['config']['waavi/translation::mode'];
 
 			if ($mode == 'auto' || empty($mode)){
@@ -99,7 +103,7 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider {
 		{
 			$languageProvider 	= new LanguageProvider($app['config']['waavi/translation::language.model']);
 			$langEntryProvider 	= new LanguageEntryProvider($app['config']['waavi/translation::language_entry.model']);
-			$fileLoader 				= new FileLoader($languageProvider, $langEntryProvider, $app);
+			$fileLoader 		= $this->app['translation.loader'];
 			return new Commands\FileLoaderCommand($languageProvider, $langEntryProvider, $fileLoader);
 		});
 	}


### PR DESCRIPTION
Command 
```bash
php artisan translator:load
```
looks up for lang files only in `[root]/app/lang` directory. 

Merging enables to load files also from registered namespaces (from packages etc.), this fixes [issue #2](https://github.com/Waavi/translation/issues/2)