### PR TITLE
Tiny typo fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,11 @@ Edit composer.json:
 		"waavi/translation": "*"
 	},
 	"repositories": [
-    {
-      "type": "vcs",
-      "url":  "git@github.com:Waavi/translation.git"
-    }
-  ],
+    	{
+      		"type": "vcs",
+      		"url":  "git@github.com:Waavi/translation.git"
+    	}
+	],
 
 In app/config/app.php, replace the following entry from the providers array:
 


### PR DESCRIPTION
Just a small typo fix in the installation readme. I didn't see this at the beginning which prevented me from using the package due to errors.