### PR TITLE
Fix empty array key in translates file

### DIFF
--- a/src/Repositories/TranslationRepository.php
+++ b/src/Repositories/TranslationRepository.php
@@ -164,7 +164,7 @@ class TranslationRepository extends Repository
         $lines = array_dot($lines);
         foreach ($lines as $item => $text) {
         
-            $text = (!$text) ?: '';
+            $text = $text ? $text : '';
             
             // Check if the entry exists in the database:
             $translation = Translation::whereLocale($locale)

--- a/src/Repositories/TranslationRepository.php
+++ b/src/Repositories/TranslationRepository.php
@@ -163,6 +163,9 @@ class TranslationRepository extends Repository
         // Transform the lines into a flat dot array:
         $lines = array_dot($lines);
         foreach ($lines as $item => $text) {
+        
+            $text = (!$text) ?: '';
+            
             // Check if the entry exists in the database:
             $translation = Translation::whereLocale($locale)
                 ->whereNamespace($namespace)


### PR DESCRIPTION
Hello. Sorry for my English!

I have got a translations file:

```php
<?php

return [
...
    'string'               => 'The :attribute must be a string.',
    'timezone'             => 'The :attribute must be a valid zone.',
    'unique'               => 'The :attribute has already been taken.',
    'url'                  => 'The :attribute format is invalid.',

    'custom' => [
        'attribute-name' => [
            'rule-name' => 'custom-message',
        ],
    ],

    'attributes' => [],

];
```

Next, we use the command:
```
php artisan translator:load
```

Result:

```[ErrorException]                                                                       
preg_replace(): Parameter mismatch, pattern is a string while replacement is an array 
```

This happens because array key "attributes" in my translations file is empty. Offer this deal to fix.