### PR TITLE
Config cache removal instruction on install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,10 +59,6 @@ Or manually edit your composer.json file:
 		"waavi/translation": "2.1.x"
 	}
 
-Publish both the configuration file and the migrations:
-
-	php artisan vendor:publish
-
 Once installed, in your project's config/app.php file replace the following entry from the providers array:
 
 	Illuminate\Translation\TranslationServiceProvider::class
@@ -70,6 +66,14 @@ Once installed, in your project's config/app.php file replace the following entr
 with:
 
 	Waavi\Translation\TranslationServiceProvider::class
+
+Remove your config cache:
+
+	php artisan config:cache
+
+Publish both the configuration file and the migrations:
+
+	php artisan vendor:publish
 
 Execute the database migrations:
 

--- a/src/Repositories/TranslationRepository.php
+++ b/src/Repositories/TranslationRepository.php
@@ -163,24 +163,26 @@ class TranslationRepository extends Repository
         // Transform the lines into a flat dot array:
         $lines = array_dot($lines);
         foreach ($lines as $item => $text) {
-            // Check if the entry exists in the database:
-            $translation = Translation::whereLocale($locale)
-                ->whereNamespace($namespace)
-                ->whereGroup($group)
-                ->whereItem($item)
-                ->first();
+            if (is_string($text)) {
+                // Check if the entry exists in the database:
+                $translation = Translation::whereLocale($locale)
+                    ->whereNamespace($namespace)
+                    ->whereGroup($group)
+                    ->whereItem($item)
+                    ->first();
 
-            // If the translation already exists, we update the text:
-            if ($translation && !$translation->isLocked()) {
-                $translation->text = $text;
-                $saved             = $translation->save();
-                if ($saved && $translation->locale === $this->defaultLocale) {
-                    $this->flagAsUnstable($namespace, $group, $item);
+                // If the translation already exists, we update the text:
+                if ($translation && !$translation->isLocked()) {
+                    $translation->text = $text;
+                    $saved             = $translation->save();
+                    if ($saved && $translation->locale === $this->defaultLocale) {
+                        $this->flagAsUnstable($namespace, $group, $item);
+                    }
                 }
-            }
-            // If no entry was found, create it:
-            else {
-                $this->create(compact('locale', 'namespace', 'group', 'item', 'text'));
+                // If no entry was found, create it:
+                else {
+                    $this->create(compact('locale', 'namespace', 'group', 'item', 'text'));
+                }
             }
         }
     }


### PR DESCRIPTION
Hi !

Without a config:cache, the vendor:publish doesn't work ! :)
The other commit fixed the translations when you have an empty array in your translation files, just like :

```
    /*
    |--------------------------------------------------------------------------
    | Custom Validation Attributes
    |--------------------------------------------------------------------------
    |
    | The following language lines are used to swap attribute place-holders
    | with something more reader friendly such as E-Mail Address instead
    | of "email". This simply helps us make messages a little cleaner.
    |
    */

    'attributes' => [],
```

First pull request, I didn't know both commits will be sent, sorry ! 

