### PR TITLE
bugfixing reverse migrations

### DIFF
--- a/database/migrations/2016_06_02_124154_increase_locale_length.php
+++ b/database/migrations/2016_06_02_124154_increase_locale_length.php
@@ -27,7 +27,7 @@ class IncreaseLocaleLength extends Migration
      */
     public function down()
     {
-        Schema::drop('translator_translations');
+        //
     }
 
 }


### PR DESCRIPTION
The command `php artisan migrate:refresh` should now work properly.
The current configuration of two migration files dropping `translator_translation` causes an error if the command mentioned above is used.