### PR TITLE
Add provides() function to expose new bindings

### DIFF
--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -132,4 +132,14 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider
         $this->app['command.translator:flush'] = $command;
         $this->commands('command.translator:flush');
     }
+
+    /**
+     *  Exposes the service container bindings provided by the translation service 
+     *
+     *  @return void
+     */
+    public function provides()
+    {
+        return array_merge(parent::provides(), ['translation.cache.repository', 'translation.uri.localizer']);
+    }
 }


### PR DESCRIPTION
Implements the solution to issue  #49  proposed by @cirdog. With the `provides()` function adding `'translation.cache.repository'` and `'translation.uri.localizer'` to the array of service container bindings provided by the TranslationServiceProvider, the "Class translation.uri.localizer does not exist" exception is no longer being thrown.