### PR TITLE
Only check if the table exists if we're allowed to use the DB

### DIFF
--- a/src/Repositories/LanguageRepository.php
+++ b/src/Repositories/LanguageRepository.php
@@ -129,11 +129,15 @@ class LanguageRepository extends Repository
         if ($this->config->has('translator.locales')) {
             return $this->config->get('translator.locales');
         }
-        if ($this->tableExists()) {
-            $locales = $this->model->distinct()->get()->pluck('locale')->toArray();
-            $this->config->set('translator.locales', $locales);
-            return $locales;
+
+        if ($this->config->get('translator.source') !== 'files') {
+            if ($this->tableExists()) {
+                $locales = $this->model->distinct()->get()->pluck('locale')->toArray();
+                $this->config->set('translator.locales', $locales);
+                return $locales;
+            }
         }
+
         return $this->defaultAvailableLocales;
     }
 


### PR DESCRIPTION
Turns out that `Route::resource()` requests attempt to load a DB (to translate URL params) even if the config is explicitly set to files only.

This is causing issues for us during our CI testing run as the app boots (and registers routes) before we create the sqlite DB from a path given in config files.

I guess it could be mitigated by adding `translator.locales` to config, but nice to have a failsafe!
