### PR TITLE
Add ability to load hinted namespaces

### DIFF
--- a/src/Loaders/CacheLoader.php
+++ b/src/Loaders/CacheLoader.php
@@ -77,6 +77,7 @@ class CacheLoader extends Loader implements LoaderInterface
      */
     public function addNamespace($namespace, $hint)
     {
+        $this->hints[$namespace] = $hint;
         $this->fallback->addNamespace($namespace, $hint);
     }
 }

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -128,7 +128,7 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider
         $languageRepository    = $app->make(LanguageRepository::class);
         $translationRepository = $app->make(TranslationRepository::class);
         $translationsPath      = $app->basePath() . '/resources/lang';
-        $command               = new FileLoaderCommand($languageRepository, $translationRepository, $app['files'], $translationsPath, $defaultLocale);
+        $command               = new FileLoaderCommand($languageRepository, $translationRepository, $app['files'], $app['translation.loader'], $translationsPath, $defaultLocale);
 
         $this->app['command.translator:load'] = $command;
         $this->commands('command.translator:load');

--- a/tests/Commands/LoadTest.php
+++ b/tests/Commands/LoadTest.php
@@ -13,7 +13,7 @@ class LoadTest extends TestCase
         $this->languageRepository    = \App::make(LanguageRepository::class);
         $this->translationRepository = \App::make(TranslationRepository::class);
         $translationsPath            = realpath(__DIR__ . '/../lang');
-        $this->command               = new FileLoaderCommand($this->languageRepository, $this->translationRepository, \App::make('files'), $translationsPath, 'en');
+        $this->command               = new FileLoaderCommand($this->languageRepository, $this->translationRepository, \App::make('files'), \App::make('translation.loader'), $translationsPath, 'en');
     }
 
     /**
@@ -104,6 +104,26 @@ class LoadTest extends TestCase
         $this->assertEquals('example', $translations[8]->group);
         $this->assertEquals('entry', $translations[8]->item);
         $this->assertEquals('Texto proveedor', $translations[8]->text);
+    }
+
+    /**
+     * @test
+     */
+    public function it_loads_hinted_namespaces_from_the_loader_correctly()
+    {
+        $this->app['translation.loader']->addNamespace('hinted', __DIR__.'/../hinted/');
+
+        $this->command->fire();
+
+        $translations = $this->translationRepository->getItems('en', 'hinted', 'translation');
+
+        $this->assertEquals(1, count($translations));
+
+        $this->assertEquals('en', $translations[0]['locale']);
+        $this->assertEquals('hinted', $translations[0]['namespace']);
+        $this->assertEquals('translation', $translations[0]['group']);
+        $this->assertEquals('by_hinting', $translations[0]['item']);
+        $this->assertEquals('It works', $translations[0]['text']);
     }
 
     /**

--- a/tests/hinted/en/translation.php
+++ b/tests/hinted/en/translation.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'by_hinting' => 'It works',
+];


### PR DESCRIPTION
First of all, thank you for the package 💯 

I've added the ability to also load translations from 'hinted' files (`loadTranslationsFrom(...)` in providers). We don't want it to be required to publish our language files before being able to load them into the database using `php artisan translator:load`.

I hope you find this addition useful. If you have any questions, I'd be happy to answer!
