### PR TITLE
Add namespaces method support from Laravel 5.4 LoaderInterface

### DIFF
--- a/src/Loaders/CacheLoader.php
+++ b/src/Loaders/CacheLoader.php
@@ -79,4 +79,14 @@ class CacheLoader extends Loader implements LoaderInterface
     {
         $this->fallback->addNamespace($namespace, $hint);
     }
+
+    /**
+     * Get an array of all the registered namespaces.
+     *
+     * @return array
+     */
+    public function namespaces()
+    {
+        return $this->fallback->namespaces();
+    }
 }

--- a/src/Loaders/DatabaseLoader.php
+++ b/src/Loaders/DatabaseLoader.php
@@ -53,4 +53,14 @@ class DatabaseLoader extends Loader implements LoaderInterface
     {
         $this->hints[$namespace] = $hint;
     }
+
+    /**
+     * Get an array of all the registered namespaces.
+     *
+     * @return array
+     */
+    public function namespaces()
+    {
+        return $this->hints;
+    }
 }

--- a/src/Loaders/FileLoader.php
+++ b/src/Loaders/FileLoader.php
@@ -57,4 +57,14 @@ class FileLoader extends Loader implements LoaderInterface
         $this->hints[$namespace] = $hint;
         $this->laravelFileLoader->addNamespace($namespace, $hint);
     }
+
+    /**
+     * Get an array of all the registered namespaces.
+     *
+     * @return array
+     */
+    public function namespaces()
+    {
+        return $this->hints;
+    }
 }

--- a/src/Loaders/Loader.php
+++ b/src/Loaders/Loader.php
@@ -63,4 +63,12 @@ abstract class Loader implements LoaderInterface
      * @return void
      */
     abstract public function addNamespace($namespace, $hint);
+
+
+    /**
+     * Get an array of all the registered namespaces.
+     *
+     * @return array
+     */
+    abstract public function namespaces();
 }

--- a/src/Loaders/MixedLoader.php
+++ b/src/Loaders/MixedLoader.php
@@ -64,4 +64,15 @@ class MixedLoader extends Loader implements LoaderInterface
         $this->hints[$namespace] = $hint;
         $this->primaryLoader->addNamespace($namespace, $hint);
     }
+
+
+    /**
+     * Get an array of all the registered namespaces.
+     *
+     * @return array
+     */
+    public function namespaces()
+    {
+        return $this->hints;
+    }
 }


### PR DESCRIPTION
Builds are failing, however this solves fresh install on Laravel 5.4.