### PR TITLE
Fix Loaders LoaderInterface for Laraval 5.5

### DIFF
--- a/src/Loaders/CacheLoader.php
+++ b/src/Loaders/CacheLoader.php
@@ -1,6 +1,6 @@
 <?php namespace Waavi\Translation\Loaders;
 
-use Illuminate\Translation\LoaderInterface;
+use Illuminate\Contracts\Translation\Loader as LoaderInterface;
 use Waavi\Translation\Cache\CacheRepositoryInterface as Cache;
 
 class CacheLoader extends Loader implements LoaderInterface

--- a/src/Loaders/DatabaseLoader.php
+++ b/src/Loaders/DatabaseLoader.php
@@ -1,6 +1,6 @@
 <?php namespace Waavi\Translation\Loaders;
 
-use Illuminate\Translation\LoaderInterface;
+use Illuminate\Contracts\Translation\Loader as LoaderInterface;
 use Waavi\Translation\Repositories\TranslationRepository;
 
 class DatabaseLoader extends Loader implements LoaderInterface

--- a/src/Loaders/FileLoader.php
+++ b/src/Loaders/FileLoader.php
@@ -1,7 +1,7 @@
 <?php namespace Waavi\Translation\Loaders;
 
 use Illuminate\Translation\FileLoader as LaravelFileLoader;
-use Illuminate\Translation\LoaderInterface;
+use Illuminate\Contracts\Translation\Loader as LoaderInterface;
 
 class FileLoader extends Loader implements LoaderInterface
 {

--- a/src/Loaders/Loader.php
+++ b/src/Loaders/Loader.php
@@ -1,7 +1,7 @@
 <?php namespace Waavi\Translation\Loaders;
 
 use Illuminate\Config\Repository as Config;
-use Illuminate\Translation\LoaderInterface;
+use Illuminate\Contracts\Translation\Loader as LoaderInterface;
 use Waavi\Translation\Repositories\LanguageRepository;
 use Waavi\Translation\Repositories\TranslationRepository;
 
@@ -71,4 +71,15 @@ abstract class Loader implements LoaderInterface
      * @return array
      */
     abstract public function namespaces();
+
+    /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJsonPath($path)
+    {
+        //
+    }
 }

--- a/src/Loaders/MixedLoader.php
+++ b/src/Loaders/MixedLoader.php
@@ -1,6 +1,6 @@
 <?php namespace Waavi\Translation\Loaders;
 
-use Illuminate\Translation\LoaderInterface;
+use Illuminate\Contracts\Translation\Loader as LoaderInterface;
 
 class MixedLoader extends Loader implements LoaderInterface
 {


### PR DESCRIPTION
Fix for issue #105 
Used LoaderInterface is relocated (Illuminate\Contracts\Translation\Loader) in Laraval 5.5 and requires method _addJsonPath_