### PR TITLE
Change fire() to handle() for Laravel 5.5

### DIFF
--- a/src/Commands/CacheFlushCommand.php
+++ b/src/Commands/CacheFlushCommand.php
@@ -38,7 +38,7 @@ class CacheFlushCommand extends Command
      *
      *  @return void
      */
-    public function fire()
+    public function handle()
     {
         if (!$this->cacheEnabled) {
             $this->info('The translation cache is disabled.');


### PR DESCRIPTION
Any fire methods present on your Artisan commands should be renamed to handle