### PR TITLE
Command handle method for Laravel 5.5

### DIFF
--- a/src/Commands/CacheFlushCommand.php
+++ b/src/Commands/CacheFlushCommand.php
@@ -47,4 +47,13 @@ class CacheFlushCommand extends Command
             $this->info('Translation cache cleared.');
         }
     }
+    
+    /**
+     * Execute the console command for Laravel 5.5
+     * this laravel version call handle intead of fire
+     */
+     public function handle()
+     {
+         $this->fire();
+     }
 }

--- a/src/Commands/FileLoaderCommand.php
+++ b/src/Commands/FileLoaderCommand.php
@@ -48,6 +48,15 @@ class FileLoaderCommand extends Command
     {
         $this->loadLocaleDirectories($this->path);
     }
+    
+    /**
+     * Execute the console command for Laravel 5.5
+     * this laravel version call handle intead of fire
+     */
+     public function handle()
+     {
+         $this->fire();
+     }
 
     /**
      *  Loads all locale directories in the given path (/en, /es, /fr) as long as the locale corresponds to a language in the database.


### PR DESCRIPTION
Trying to load my translation a get this error
[ReflectionException]
  Method Waavi\Translation\Commands\FileLoaderCommand::hand
  le() does not exist
after some googling I find out that in newest Laravel versions the method handle is called instead of fire.
post referende: https://laracasts.com/discuss/channels/laravel/tinkercommandhandle-does-not-exist

I was tempted to use Trait instead of injecting directly the method, that would be more elegant, but I choose the easiest way.