### PR TITLE
Remove unnecessary database queries

### DIFF
--- a/config/translator.php
+++ b/config/translator.php
@@ -16,7 +16,7 @@ return [
     |   'database'      Use the database as the exclusive source for language entries.
     |   'files'         Use files as the exclusive source for language entries [Laravel's default].
      */
-    'source'            => env('TRANSLATION_SOURCE', 'mixed'),
+    'source'            => env('TRANSLATION_SOURCE', 'files'),
 
     // In case the files source is selected, please enter here the supported locales for your app.
     // Ex: ['en', 'es', 'fr']

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ This package allows you to load translation from the regular Laravel localizatio
  - 'mixed'		To load translations both from the filesystem and the database, with the filesystem having priority.
  - 'mixed_db'   To load translations both from the filesystem and the database, with the database having priority. [v2.1.5.3]
 
+NOTE: When adding the package to an existing Laravel project, 'files' must be used until migrations have been executed.
+
 For cache configuration, please go to [cache configuration](#cache-translations)
 
 ### Load translations from files

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -72,10 +72,6 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider
             $defaultLocale = $app['config']->get('app.locale');
             $loader        = null;
             $source        = $app['config']->get('translator.source');
-            // Default source to 'files' if translations table do not exist:
-            if ($source !== 'files' && app()->environment() !== 'testing') {
-                $source = \Schema::hasTable('translator_languages') && \Schema::hasTable('translator_translations') ? $source : 'files';
-            }
 
             switch ($source) {
                 case 'mixed':


### PR DESCRIPTION
See #111.
The config change is required to have a usable default (also brings the code in line with the documentation which states that 'files' is default).