### PR TITLE
Ensure we cascade namespaces to secondary loaders

### DIFF
--- a/src/Loaders/MixedLoader.php
+++ b/src/Loaders/MixedLoader.php
@@ -61,6 +61,7 @@ class MixedLoader extends Loader
     {
         $this->hints[$namespace] = $hint;
         $this->primaryLoader->addNamespace($namespace, $hint);
+        $this->secondaryLoader->addNamespace($namespace, $hint);
     }
 
     /**

--- a/tests/Commands/LoadTest.php
+++ b/tests/Commands/LoadTest.php
@@ -53,7 +53,7 @@ class LoadTest extends TestCase
     {
         $directory = realpath(__DIR__ . '/../lang/es');
         $this->command->loadDirectory($directory, 'es');
-        $translations = $this->translationRepository->all();
+        $translations = $this->translationRepository->all()->sortBy('id');
 
         $this->assertEquals(2, $translations->count());
 
@@ -89,21 +89,21 @@ class LoadTest extends TestCase
     {
         $this->command->handle();
 
-        $translations = $this->translationRepository->all();
+        $translations = $this->translationRepository->all()->sortBy('id');
 
         $this->assertEquals(9, $translations->count());
 
-        $this->assertEquals('en', $translations[7]->locale);
+        $this->assertEquals('es', $translations[7]->locale);
         $this->assertEquals('package', $translations[7]->namespace);
         $this->assertEquals('example', $translations[7]->group);
         $this->assertEquals('entry', $translations[7]->item);
-        $this->assertEquals('Vendor text', $translations[7]->text);
+        $this->assertEquals('Texto proveedor', $translations[7]->text);
 
-        $this->assertEquals('es', $translations[8]->locale);
+        $this->assertEquals('en', $translations[8]->locale);
         $this->assertEquals('package', $translations[8]->namespace);
         $this->assertEquals('example', $translations[8]->group);
         $this->assertEquals('entry', $translations[8]->item);
-        $this->assertEquals('Texto proveedor', $translations[8]->text);
+        $this->assertEquals('Vendor text', $translations[8]->text);
     }
 
     /**

--- a/tests/Commands/LoadTest.php
+++ b/tests/Commands/LoadTest.php
@@ -89,21 +89,12 @@ class LoadTest extends TestCase
     {
         $this->command->handle();
 
-        $translations = $this->translationRepository->all()->sortBy('id');
+        $translations = $this->translationRepository->all();
 
         $this->assertEquals(9, $translations->count());
 
-        $this->assertEquals('es', $translations[7]->locale);
-        $this->assertEquals('package', $translations[7]->namespace);
-        $this->assertEquals('example', $translations[7]->group);
-        $this->assertEquals('entry', $translations[7]->item);
-        $this->assertEquals('Texto proveedor', $translations[7]->text);
-
-        $this->assertEquals('en', $translations[8]->locale);
-        $this->assertEquals('package', $translations[8]->namespace);
-        $this->assertEquals('example', $translations[8]->group);
-        $this->assertEquals('entry', $translations[8]->item);
-        $this->assertEquals('Vendor text', $translations[8]->text);
+        $this->assertEquals('Texto proveedor', $translations->where('locale', 'es')->where('namespace', 'package')->where('group', 'example')->where('item', 'entry')->first()->text);
+        $this->assertEquals('Vendor text', $translations->where('locale', 'en')->where('namespace', 'package')->where('group', 'example')->where('item', 'entry')->first()->text);
     }
 
     /**

--- a/tests/Loaders/MixedLoaderTest.php
+++ b/tests/Loaders/MixedLoaderTest.php
@@ -44,4 +44,14 @@ class MixedLoaderTest extends TestCase
         $this->dbLoader->shouldReceive('loadSource')->with('en', 'group', 'name')->andReturn($db);
         $this->assertEquals($expected, $this->mixedLoader->load('en', 'group', 'name'));
     }
+
+    /**
+     * @test
+     */
+    public function it_cascades_namespaces()
+    {
+        $this->fileLoader->shouldReceive('addNamespace')->with('package', '/some/path/to/package')->andReturnNull();
+        $this->dbLoader->shouldReceive('addNamespace')->with('package', '/some/path/to/package')->andReturnNull();
+        $this->assertNull($this->mixedLoader->addNamespace('package', '/some/path/to/package'));
+    }
 }


### PR DESCRIPTION
Ideally needs to be backported to 2.2.* for Laravel 5.4 as well