### PR TITLE
Update 2013_07_25_145958_create_translations_table.php

### DIFF
--- a/database/migrations/2013_07_25_145958_create_translations_table.php
+++ b/database/migrations/2013_07_25_145958_create_translations_table.php
@@ -15,9 +15,9 @@ class CreateTranslationsTable extends Migration
         Schema::connection(config('translator.connection'))->create('translator_translations', function ($table) {
             $table->increments('id');
             $table->string('locale', 6);
-            $table->string('namespace')->default('*');
-            $table->string('group');
-            $table->string('item');
+            $table->string('namespace', 150)->default('*');
+            $table->string('group', 150);
+            $table->string('item', 150);
             $table->text('text');
             $table->boolean('unstable')->default(false);
             $table->boolean('locked')->default(false);


### PR DESCRIPTION
Add length limiters for namespace, group and item.

This fixes an issue where the index will fail creation on a utf8mb4_unicode_ci collation as the max length is 3,072 bytes and the current gives us 3,084 bytes ((255+255+255+6) * 4) from the four columns used in the index.