### PR TITLE
Laravel 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "laravel/framework": "~6.0|~7.0",
-        "doctrine/dbal": "^2.5"
+        "laravel/framework": "~8.0",
+        "doctrine/dbal": "^2.5.2"
     },
     "require-dev": {
-        "phpunit/phpunit" : "~8.3",
-        "orchestra/testbench": "~4.0",
-        "mockery/mockery": "^1.2.3"
+        "phpunit/phpunit" : "~9.1",
+        "orchestra/testbench": "~6.0",
+        "mockery/mockery": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Translation Test Suite">

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ WAAVI is a web development studio based in Madrid, Spain. You can learn more abo
  5.5.x    | 2.3.x and higher
  5.6.x    | 2.3.x and higher
  6.x\|7.x     | 2.4.x and higher
+ 8.x.x    | 2.5.x and higher
+
 ## Features overview
 
  - Allow dynamic changes to the site's text and translations.
@@ -54,12 +56,12 @@ WAAVI is a web development studio based in Madrid, Spain. You can learn more abo
 Require through composer
 
 
-	composer require waavi/translation 2.3.x
+	composer require waavi/translation 2.5.x
 
 Or manually edit your composer.json file:
 
 	"require": {
-		"waavi/translation": "2.3.x"
+		"waavi/translation": "2.5.x"
 	}
 
 Once installed, in your project's config/app.php file replace the following entry from the providers array:


### PR DESCRIPTION
### Update for Travis 
PHP travis version updated to 7.4

### Updates for composer
**laravel** version updated to ^8.0
**phpunit** version updated to ~9.1
**testbench** version updated to ~6.0
**mockery** version updated to ^1.3

_You should set the release tag "2.5" for this PR._

Regards.